### PR TITLE
Adding missing dependency to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   ],
   "dependencies": {
     "class.extend": "0.9.2",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "lodash": "^4.16.4"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
I was getting error when running serverless function because of the lodash module missing.
