### PR TITLE
Added `lodash` module to dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     }
   ],
   "dependencies": {
+    "lodash": "4.17.2",
     "class.extend": "0.9.2",
     "underscore": "1.8.3"
   },


### PR DESCRIPTION
package.json was missing the lodash module, which is `require()`'d by index.js of the plugin at line 3.