### PR TITLE
Changed hook to avoid clashing with other plugins like serverless-dom…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ module.exports = Class.extend({
     this._opts = opts;
 
     this.hooks = {
-      'before:deploy:deploy': this.addStageVariables.bind(this),
+      'after:package:compileEvents': this.addStageVariables.bind(this),
     };
   },
 


### PR DESCRIPTION
…ain-manager

Background:
I discovered an issue with this plugin. If you use for example serverless-domain-manager the deployment fails, because the stage needed is not present yet. Kudos to majones-amplify who pointed me to the right direction.

See also here: https://github.com/amplify-education/serverless-domain-manager/issues/68

This pull request avoids that clashing and I tested this as working correctly for me