### PR TITLE
Check `custom` has been defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ module.exports = Class.extend({
 
     // setup variables, if any are defined
     var variables = {};
-    if (this._serverless.service.custom.stageVariables) {
+    if (this._serverless.service.custom && this._serverless.service.custom.stageVariables) {
       variables = this._serverless.service.custom.stageVariables;
     }
 


### PR DESCRIPTION
If you don't have a `custom` block in `serverless.yml`, this plugin throws an error.