### PR TITLE
Update lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/svdgraaf/serverless-plugin-stage-variables"
   },
   "dependencies": {
-    "lodash": "4.17.2",
+    "lodash": "4.17.10",
     "class.extend": "0.9.2"
   },
   "license": "MIT",


### PR DESCRIPTION
lodash has vulnerability in versions before 4.7.5, see https://nodesecurity.io/advisories/577. This looks like safe update, but I haven't done any comprehensive testing.