### PR TITLE
Add TestDeployment Ref for DeploymentId

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ module.exports = Class.extend({
         StageName: stage,
         Description: stage,
         RestApiId: {"Ref": "ApiGatewayRestApi"},
-        DeploymentId: null,
+        DeploymentId: {"Ref": "TestDeployment"},
         Variables: variables,
       }
     }


### PR DESCRIPTION
Fixes #15 

Found the `Ref` inside an Example here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html