### PR TITLE
Added fix for lost 'this' context

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ module.exports = Class.extend({
         this._serverless.cli.log(
           '\t' + key
         );
-      });
+      }, this);
     }
 
     // find the correct stage name


### PR DESCRIPTION
Fix for:
Serverless: STAGING VARS: Loading variables.
 
  Type Error ---------------------------------------------
 
  Cannot read property '_serverless' of undefined
 
     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.
 
  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com
 
  Your Environment Information ---------------------------
     OS:                     linux
     Node Version:           8.11.3
     Serverless Version:     1.41.1
 
npm ERR! code ELIFECYCLE
npm ERR! errno 1
