### PR TITLE
Fix stage resolution

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,10 +32,7 @@ module.exports = Class.extend({
     }
 
     // find the correct stage name
-    var stage = this._serverless.service.provider.stage;
-    if (this._serverless.variables.options.stage) {
-      stage = this._serverless.variables.options.stage;
-    }
+    var stage = this._serverless.getProvider('aws').getStage();
 
     // override the deployment config, which can be ignored, see:
     // http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-deployment.html


### PR DESCRIPTION
`serverless.variables` is scheduled to not be accessible in next Framework release.

Additionally so far used method would not work for some configuration cases